### PR TITLE
Update serializers.py for netbox >= 4.1

### DIFF
--- a/netbox_gateways/api/serializers.py
+++ b/netbox_gateways/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from ipam.api.serializers import NestedPrefixSerializer, NestedIPAddressSerializer
+from ipam.api.serializers import PrefixSerializer, IPAddressSerializer
 from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
 from ..models import Gateway  # , GatewayRule
 
@@ -30,8 +30,8 @@ class GatewaySerializer(NetBoxModelSerializer):
         view_name="plugins-api:netbox_gateways-api:gateway-detail",
     )
 
-    prefix = NestedPrefixSerializer()
-    gateway_ip = NestedIPAddressSerializer()
+    prefix = PrefixSerializer(nested=True)
+    gateway_ip = IPAddressSerializer(nested=True)
 
     class Meta:
         model = Gateway


### PR DESCRIPTION
NestedSerializers have been moved to netbox.api.nested_serializers, with a warning that they will be removed in netbox v4.2. See https://github.com/netbox-community/netbox/blob/develop/netbox/ipam/api/nested_serializers.py#L31